### PR TITLE
Implement ERC-1155 burn hook

### DIFF
--- a/src/hook/burn/BurnHookERC1155.sol
+++ b/src/hook/burn/BurnHookERC1155.sol
@@ -18,7 +18,7 @@ contract BurnHookERC1155 is IBurnRequest, EIP712, ERC1155Hook {
                                CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The EIP-712 typehash for the mint request struct.
+    /// @notice The EIP-712 typehash for the burn request struct.
     bytes32 private constant TYPEHASH =
         keccak256(
             "BurnRequest(address token,uint256 tokenId,address owner,uint256 quantity,bytes permissionSignature,uint128 sigValidityStartTimestamp,uint128 sigValidityEndTimestamp,bytes32 sigUid)"
@@ -66,7 +66,7 @@ contract BurnHookERC1155 is IBurnRequest, EIP712, ERC1155Hook {
         return BEFORE_BURN_FLAG();
     }
 
-    /// @notice Returns the signature of the arguments expected by the beforeMint hook.
+    /// @notice Returns the signature of the arguments expected by the beforeBurn hook.
     function getBeforeBurnArgSignature() external pure override returns (string memory argSignature) {
         argSignature = "address,uint256,address,uint256,bytes,uint128,uint128,bytes32,";
     }
@@ -146,7 +146,7 @@ contract BurnHookERC1155 is IBurnRequest, EIP712, ERC1155Hook {
         return true;
     }
 
-    /// @dev Returns the address of the signer of the mint request.
+    /// @dev Returns the address of the signer of the burn request.
     function _recoverAddress(BurnRequest memory _req) internal view returns (address) {
         return
             _hashTypedData(

--- a/src/hook/burn/BurnHookERC1155.sol
+++ b/src/hook/burn/BurnHookERC1155.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import { ERC1155Hook } from "../ERC1155Hook.sol";
+import { EIP712 } from "@solady/utils/EIP712.sol";
+import { ECDSA } from "@solady/utils/ECDSA.sol";
+
+import { IPermission } from "../../interface/common/IPermission.sol";
+import { IBurnRequest } from "../../interface/common/IBurnRequest.sol";
+
+
+import { BurnHookERC1155Storage } from "../../storage/hook/burn/BurnHookERC1155Storage.sol";
+
+contract BurnHookERC1155 is IBurnRequest, EIP712, ERC1155Hook {
+   using ECDSA for bytes32;
+
+    /*//////////////////////////////////////////////////////////////
+                               CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice The EIP-712 typehash for the mint request struct.
+    bytes32 private constant TYPEHASH =
+        keccak256(
+            "BurnRequest(address token,uint256 tokenId,address owner,uint256 quantity,bytes permissionSignature,uint128 sigValidityStartTimestamp,uint128 sigValidityEndTimestamp,bytes32 sigUid)"
+        );
+
+
+    /*//////////////////////////////////////////////////////////////
+                               ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Error when the signature is invalid.
+    error BurnHookInvalidSignature();
+
+    /// @notice Error when the request has expired.
+    error BurnHookRequestExpired();
+
+    /// @notice Error when the request has been used.
+    error BurnHookRequestUsed();
+
+    /// @notice Error when the recipient is invalid.
+    error BurnHookInvalidRecipient();
+
+    /// @notice Error when the token is invalid.
+    error BurnHookNotToken();
+
+    /// @notice Error when the quantity is invalid.
+    error BurnHookInvalidQuantity(uint256 _quantity);
+
+    /// @notice Error when the token ID is invalid.
+    error BurnHookInvalidTokenId(uint256 _tokenId);
+
+    /*//////////////////////////////////////////////////////////////
+                                INITIALIZE
+    //////////////////////////////////////////////////////////////*/
+
+    function initialize(address _upgradeAdmin) public initializer {
+        __ERC1155Hook_init(_upgradeAdmin);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function getHooks() external pure override returns (uint256) {
+        return BEFORE_BURN_FLAG();
+    }
+
+    /// @notice Returns the signature of the arguments expected by the beforeMint hook.
+    function getBeforeBurnArgSignature() external pure override returns (string memory argSignature) {
+        argSignature = "address,uint256,address,uint256,bytes,uint128,uint128,bytes32,";
+    }
+
+    /// @dev Returns the domain name and version for the EIP-712 domain separator
+    function _domainNameAndVersion() internal pure override returns (string memory name, string memory version) {
+        name = "BurnHookERC1155";
+        version = "1";
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            BEFORE BURN HOOK
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     *  @notice The beforeBurn hook that is called by a core token before burning a token.
+     *  @param _from The address that is burning tokens.
+     *  @param _id The token ID being burned.
+     *  @param _value The quantity of tokens being burned.
+     *  @param _encodedArgs The encoded arguments for the beforeBurn hook.
+     */
+    function beforeBurn(
+        address _from,
+        uint256 _id,
+        uint256 _value,
+        bytes memory _encodedArgs
+    ) external override {
+        BurnRequest memory req = abi.decode(_encodedArgs, (BurnRequest));
+        
+        if (req.token != msg.sender) {
+            revert BurnHookNotToken();
+        }
+
+        if (req.quantity != _value) {
+            revert BurnHookInvalidQuantity(_value);
+        }
+
+        if (req.owner != _from) {
+            revert BurnHookInvalidRecipient();
+        }
+        if (req.tokenId != _id) {
+            revert BurnHookInvalidTokenId(_id);
+        }
+
+        if (req.permissionSignature.length <= 0) {
+             revert BurnHookInvalidSignature();
+        }  
+        
+        BurnHookERC1155Storage.Data storage data = BurnHookERC1155Storage.data();
+        verifyPermissionedClaim(req);
+        data.uidUsed[req.sigUid] = true;
+        
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            SIGNATURE FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     *  @notice Verifies that a given permissioned claim is valid
+     *
+     *  @param _req The burn request to check.
+     */
+    function verifyPermissionedClaim(BurnRequest memory _req) public view returns (bool) {
+        if (block.timestamp < _req.sigValidityStartTimestamp || _req.sigValidityEndTimestamp <= block.timestamp) {
+            revert BurnHookRequestExpired();
+        }
+        if (BurnHookERC1155Storage.data().uidUsed[_req.sigUid]) {
+            revert BurnHookRequestUsed();
+        }
+
+        address signer = _recoverAddress(_req);
+        if (!IPermission(_req.token).hasRole(signer, ADMIN_ROLE_BITS)) {
+            revert BurnHookInvalidSignature();
+        }
+
+        return true;
+    }
+
+    /// @dev Returns the address of the signer of the mint request.
+    function _recoverAddress(BurnRequest memory _req) internal view returns (address) {
+        return
+            _hashTypedData(
+                keccak256(
+                    abi.encode(
+                        TYPEHASH,
+                        _req.token,
+                        _req.tokenId,
+                        _req.owner,
+                        _req.quantity,
+                        keccak256(bytes("")),
+                        _req.sigValidityStartTimestamp,
+                        _req.sigValidityEndTimestamp,
+                        _req.sigUid
+                    )
+                )
+            ).recover(_req.permissionSignature);
+    }
+}

--- a/src/interface/common/IBurnRequest.sol
+++ b/src/interface/common/IBurnRequest.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface IBurnRequest {
+    /**
+     *  @notice Represents a burn request on a Burn hook.
+     *
+     *  @param token The address of the token to be minted.
+     *  @param tokenId The id of the token to be minted. Ingnored for ERC-20 and ERC-721 burn hooks.
+     *  @param owner The address of the owner.
+     *  @param quantity The quantity of tokens to be burned.
+     *  @param permissionSignature The signature of the token contract admin authorizing burning of tokens.
+     *  @param sigValidityStartTimestamp The timestamp from which the signature is valid.
+     *  @param sigValidityEndTimestamp The timestamp until which the signature is valid.
+     *  @param sigUid The unique id of the signature.
+     */
+    struct BurnRequest {
+        address token;
+        uint256 tokenId;
+        address owner;
+        uint256 quantity;
+        bytes permissionSignature;
+        uint128 sigValidityStartTimestamp;
+        uint128 sigValidityEndTimestamp;
+        bytes32 sigUid;
+    }
+}

--- a/src/interface/common/IBurnRequest.sol
+++ b/src/interface/common/IBurnRequest.sol
@@ -5,8 +5,8 @@ interface IBurnRequest {
     /**
      *  @notice Represents a burn request on a Burn hook.
      *
-     *  @param token The address of the token to be minted.
-     *  @param tokenId The id of the token to be minted. Ingnored for ERC-20 and ERC-721 burn hooks.
+     *  @param token The address of the token to be burned.
+     *  @param tokenId The id of the token to be burned. Ingnored for ERC-20 and ERC-721 burn hooks.
      *  @param owner The address of the owner.
      *  @param quantity The quantity of tokens to be burned.
      *  @param permissionSignature The signature of the token contract admin authorizing burning of tokens.

--- a/src/storage/hook/burn/BurnHookERC1155Storage.sol
+++ b/src/storage/hook/burn/BurnHookERC1155Storage.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import { BurnHookERC1155 } from "../../../hook/burn/BurnHookERC1155.sol";
+import { IClaimCondition } from "../../../interface/common/IClaimCondition.sol";
+import { IFeeConfig } from "../../../interface/common/IFeeConfig.sol";
+
+library BurnHookERC1155Storage {
+    /// @custom:storage-location erc7201:burn.hook.erc1155.storage
+    /// @dev keccak256(abi.encode(uint256(keccak256("burn.hook.erc1155.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 public constant BURN_HOOK_ERC1155_STORAGE_POSITION =
+        0x9dba7bf1a1a69a0404002647b9ae71814c164e94c530a544d28db5298de88000;
+
+    struct Data {
+        /// @dev Mapping from permissioned burn request UID => whether the burn request is processed.
+        mapping(bytes32 => bool) uidUsed;
+    }
+
+    function data() internal pure returns (Data storage data_) {
+        bytes32 position = BURN_HOOK_ERC1155_STORAGE_POSITION;
+        assembly {
+            data_.slot := position
+        }
+    }
+}

--- a/test/hook/BurnHookERC1155.t.sol
+++ b/test/hook/BurnHookERC1155.t.sol
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { Merkle } from "@murky/Merkle.sol";
+import "forge-std/console2.sol";
+
+import { MockERC20 } from "test/mocks/MockERC20.sol";
+import { CloneFactory } from "src/infra/CloneFactory.sol";
+import { EIP1967Proxy } from "src/infra/EIP1967Proxy.sol";
+
+import { IHook } from "src/interface/hook/IHook.sol";
+
+import { ERC1155Core, HookInstaller } from "src/core/token/ERC1155Core.sol";
+import { BurnHookERC1155, ERC1155Hook } from "src/hook/burn/BurnHookERC1155.sol";
+
+import { EmptyHookERC1155 } from "../mocks/EmptyHook.sol";
+
+import { IBurnRequest } from "src/interface/common/IBurnRequest.sol";
+
+import { IClaimCondition } from "src/interface/common/IClaimCondition.sol";
+import { IFeeConfig } from "src/interface/common/IFeeConfig.sol";
+
+contract MintHookERC1155Test is Test {
+    /*//////////////////////////////////////////////////////////////
+                                SETUP
+    //////////////////////////////////////////////////////////////*/
+
+    // Participants
+    address public platformAdmin = address(0x123);
+
+    uint256 developerPKey = 100;
+    address public developer;
+
+    address public endUser = 0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd;
+
+    // Target test contracts
+    ERC1155Core public erc1155Core;
+    BurnHookERC1155 public BurnHook;
+    EmptyHookERC1155 public MintHook;
+
+    // Test params
+    uint256 public constant BEFORE_MINT_FLAG = 2 ** 3;
+    bytes32 private constant TYPEHASH =
+        keccak256(
+            "BurnRequest(address token,uint256 tokenId,address owner,uint256 quantity,bytes permissionSignature,uint128 sigValidityStartTimestamp,uint128 sigValidityEndTimestamp,bytes32 sigUid)"
+        );
+    bytes32 public domainSeparator;
+
+    bytes32 public allowlistRoot;
+    bytes32[] public allowlistProof;
+
+    function _setupDomainSeparator(address _BurnHook) internal {
+        bytes32 nameHash = keccak256(bytes("BurnHookERC1155"));
+        bytes32 versionHash = keccak256(bytes("1"));
+        bytes32 typehashEip712 = keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+        domainSeparator = keccak256(abi.encode(typehashEip712, nameHash, versionHash, block.chainid, _BurnHook));
+    }
+
+    function setUp() public {
+        developer = vm.addr(developerPKey);
+
+        // Platform deploys burn hook.
+        vm.startPrank(platformAdmin);
+
+        address BurnHookImpl = address(new BurnHookERC1155());
+
+        bytes memory initData = abi.encodeWithSelector(
+            BurnHookERC1155.initialize.selector,
+            platformAdmin // upgradeAdmin
+        );
+        address BurnHookProxy = address(new EIP1967Proxy(BurnHookImpl, initData));
+        BurnHook = BurnHookERC1155(BurnHookProxy);
+
+        //Set up empty mint hook for minting as its required by the ERC1155Core
+        address EmptyHookImpl = address(new EmptyHookERC1155());
+
+        bytes memory emptyHookInitData = abi.encodeWithSelector(
+            EmptyHookERC1155.initialize.selector,
+            platformAdmin // upgradeAdmin
+        );
+        address EmptyHookProxy = address(new EIP1967Proxy(EmptyHookImpl, emptyHookInitData));
+        MintHook = EmptyHookERC1155(EmptyHookProxy);
+
+        // Platform deploys ERC1155 core implementation and clone factory.
+        address erc1155CoreImpl = address(new ERC1155Core());
+        CloneFactory factory = new CloneFactory();
+
+        vm.stopPrank();
+
+        // Setup domain separator of burn hook for signature minting.
+        _setupDomainSeparator(BurnHookProxy);
+
+        // Developer deploys proxy for ERC1155 core with BurnHookERC1155 preinstalled.
+        vm.startPrank(developer);
+
+        ERC1155Core.InitCall memory initCall;
+        address[] memory preinstallHooks = new address[](2);
+        preinstallHooks[0] = address(MintHook);
+        preinstallHooks[1] = address(BurnHook);
+
+        bytes memory erc1155InitData = abi.encodeWithSelector(
+            ERC1155Core.initialize.selector,
+            initCall,
+            preinstallHooks,
+            developer, // core contract admin
+            "Test ERC1155",
+            "TST",
+            "ipfs://QmPVMvePSWfYXTa8haCbFavYx4GM4kBPzvdgBw7PTGUByp/0" // mock contract URI of actual length
+        );
+        erc1155Core = ERC1155Core(
+            factory.deployProxyByImplementation(erc1155CoreImpl, erc1155InitData, bytes32("salt"))
+        );
+
+        vm.stopPrank();
+
+
+        // Set labels
+        vm.deal(endUser, 100 ether);
+
+        vm.label(platformAdmin, "Admin");
+        vm.label(developer, "Developer");
+        vm.label(endUser, "Claimer");
+
+        vm.label(address(erc1155Core), "ERC1155Core");
+        vm.label(address(BurnHookImpl), "BurnHookERC1155");
+        vm.label(BurnHookProxy, "ProxyBurnHookERC1155");
+
+        // Log for the storage slot of BurnHookERC1155 (for the storage location file BurnHookERC1155Storage.sol)
+        bytes32 storageSlot = keccak256(abi.encode(uint256(keccak256("burn.hook.erc1155.storage")) - 1)) & ~bytes32(uint256(0xff));
+        console2.logBytes32( storageSlot);
+    }
+
+    function _signBurnRequest(
+        IBurnRequest.BurnRequest memory _req,
+        uint256 _privateKey
+    ) internal view returns (bytes memory) {
+        bytes memory encodedRequest = abi.encode(
+            TYPEHASH,
+            _req.token,
+            _req.tokenId,
+            _req.owner,
+            _req.quantity,
+            keccak256(bytes("")),
+            _req.sigValidityStartTimestamp,
+            _req.sigValidityEndTimestamp,
+            _req.sigUid
+        );
+        bytes32 structHash = keccak256(encodedRequest);
+        bytes32 typedDataHash = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, typedDataHash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        return sig;
+    }
+
+    function mintForAddress(address _to, uint256 _id, uint256 _quantity) internal {
+        vm.prank(_to);
+        erc1155Core.mint(address(_to), _id, _quantity, "");
+        vm.stopPrank();
+    }
+
+    function test_beforeBurn_mintTokenToUser_success() public {   
+        mintForAddress(endUser, 1337, 1);
+        assertEq(erc1155Core.balanceOf(address(endUser), 1337), 1);
+        assertEq(erc1155Core.totalSupply(1337),1);
+
+    }
+    
+    function test_beforeBurn_successfulBurnCase() public {
+        //TokenId
+        uint256 tokenId = 1337;
+        // Minting 1 token to endUser
+        mintForAddress(endUser, tokenId, 1);
+        assertEq(erc1155Core.balanceOf(address(endUser), tokenId), 1);
+
+        // Create request with happy path signature
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, developerPKey);
+        req.permissionSignature = sig;
+
+        assertEq(erc1155Core.balanceOf(endUser, tokenId), 1);
+        assertEq(erc1155Core.totalSupply(tokenId), 1);
+
+        // Burn the token
+        vm.prank(endUser);
+        erc1155Core.burn(req.owner, req.tokenId, req.quantity, abi.encode(req));
+
+        assertEq(erc1155Core.balanceOf(endUser, tokenId), 0);
+        assertEq(erc1155Core.totalSupply(tokenId), 0); 
+    }
+
+    function test_beforeBurn_revert_burnHookNotToken() public {
+       uint256 tokenId = 1337;
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(0x999), // use not the token address
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, developerPKey);
+        req.permissionSignature = sig;
+
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookNotToken.selector));
+        erc1155Core.burn(req.owner, req.tokenId, req.quantity, abi.encode(req));
+    }
+
+    function test_beforeBurn_revert_burnHookInvalidQuantity() public {
+        uint256 tokenId = 1337;
+        uint256 quantityInReqest = 1;
+        uint256 invalidQuantity = 2;
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: quantityInReqest, // use different quantity
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, developerPKey);
+        req.permissionSignature = sig;
+
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookInvalidQuantity.selector, 2));
+        // Burn the token with different quantity
+        erc1155Core.burn(req.owner, req.tokenId, invalidQuantity, abi.encode(req));
+    }
+
+    function test_beforeBurn_revert_burnHookInvalidRecipient() public {
+        uint256 tokenId = 1337;
+        address invalidOwner = address(0x999);
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, developerPKey);
+        req.permissionSignature = sig;
+
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookInvalidRecipient.selector));
+        // Burn the token with different owner
+        erc1155Core.burn(invalidOwner, req.tokenId, req.quantity, abi.encode(req));
+    }
+
+    function test_beforeBurn_revert_permissionlessBurn_invalidTokenId() public {
+        uint256 tokenId = 1337;
+        uint256 invalidTokenId = 1338;
+
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId, // use different token id
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, developerPKey);
+        req.permissionSignature = sig;
+
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookInvalidTokenId.selector, invalidTokenId));
+        // Burn the token with different token id
+        erc1155Core.burn(req.owner, invalidTokenId, req.quantity, abi.encode(req));
+    }
+
+    function test_beforeBurn_revert_burnHookInvalidSignature() public {
+        uint256 tokenId = 1337;
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0), // use empty signature and don't replace below
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookInvalidSignature.selector));
+        // Burn the token with invalid signature
+        erc1155Core.burn(req.owner, req.tokenId, req.quantity, abi.encode(req));
+    }
+
+    function test_beforeBurn_revert_burnHookRequestExpired() public {
+        uint256 tokenId = 1337;
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 0, // use expired signature
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, developerPKey);
+        req.permissionSignature = sig;
+
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookRequestExpired.selector));
+        // Burn the token with expired signature
+        erc1155Core.burn(req.owner, req.tokenId, req.quantity, abi.encode(req));
+    }
+
+    function test_beforeBurn_revert_burnHookRequestUsed() public {
+        uint256 tokenId = 1337;
+        // Minting 1 token to endUser so that first burn can be successful
+        mintForAddress(endUser, tokenId, 1);
+        assertEq(erc1155Core.balanceOf(address(endUser), tokenId), 1);
+
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, developerPKey);
+        req.permissionSignature = sig;
+
+        // Burn the token
+        vm.prank(endUser);
+        erc1155Core.burn(req.owner, req.tokenId, req.quantity, abi.encode(req));
+        vm.stopPrank();
+
+        // Burn the token with the same signature
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookRequestUsed.selector));
+        erc1155Core.burn(req.owner, req.tokenId, req.quantity, abi.encode(req));
+    }
+
+    function test_verifyPermissionClaim_revert_burnHookInvalidSignature() public {
+        uint256 tokenId = 1337;
+        // Create burn request
+        IBurnRequest.BurnRequest memory req = IBurnRequest.BurnRequest({
+            token: address(erc1155Core),
+            tokenId: tokenId,
+            owner: endUser,
+            quantity: 1,
+            permissionSignature: new bytes(0),
+            sigValidityStartTimestamp: 0,
+            sigValidityEndTimestamp: 200,
+            sigUid: bytes32("random-1")
+        });
+
+        bytes memory sig = _signBurnRequest(req, 0x999); // use different private key
+        req.permissionSignature = sig;
+
+        vm.prank(endUser);
+        vm.expectRevert(abi.encodeWithSelector(BurnHookERC1155.BurnHookInvalidSignature.selector));
+        // Burn the token with invalid signature
+        erc1155Core.burn(req.owner, req.tokenId, req.quantity, abi.encode(req));
+    }
+}

--- a/test/hook/BurnHookERC1155.t.sol
+++ b/test/hook/BurnHookERC1155.t.sol
@@ -21,7 +21,7 @@ import { IBurnRequest } from "src/interface/common/IBurnRequest.sol";
 import { IClaimCondition } from "src/interface/common/IClaimCondition.sol";
 import { IFeeConfig } from "src/interface/common/IFeeConfig.sol";
 
-contract MintHookERC1155Test is Test {
+contract BurnHookERC1155Test is Test {
     /*//////////////////////////////////////////////////////////////
                                 SETUP
     //////////////////////////////////////////////////////////////*/
@@ -40,7 +40,7 @@ contract MintHookERC1155Test is Test {
     EmptyHookERC1155 public MintHook;
 
     // Test params
-    uint256 public constant BEFORE_MINT_FLAG = 2 ** 3;
+    uint256 public constant BEFORE_BURN_FLAG = 2 ** 3;
     bytes32 private constant TYPEHASH =
         keccak256(
             "BurnRequest(address token,uint256 tokenId,address owner,uint256 quantity,bytes permissionSignature,uint128 sigValidityStartTimestamp,uint128 sigValidityEndTimestamp,bytes32 sigUid)"
@@ -74,7 +74,7 @@ contract MintHookERC1155Test is Test {
         address BurnHookProxy = address(new EIP1967Proxy(BurnHookImpl, initData));
         BurnHook = BurnHookERC1155(BurnHookProxy);
 
-        //Set up empty mint hook for minting as its required by the ERC1155Core
+        // Set up empty mint hook for minting as its required by the ERC1155Core
         address EmptyHookImpl = address(new EmptyHookERC1155());
 
         bytes memory emptyHookInitData = abi.encodeWithSelector(
@@ -90,7 +90,7 @@ contract MintHookERC1155Test is Test {
 
         vm.stopPrank();
 
-        // Setup domain separator of burn hook for signature minting.
+        // Setup domain separator of burn hook for signature burning.
         _setupDomainSeparator(BurnHookProxy);
 
         // Developer deploys proxy for ERC1155 core with BurnHookERC1155 preinstalled.


### PR DESCRIPTION
This Pull request creates a hook with the same Proxy pattern as the `MintHookERC1155`. Test suite included.

The goal of the functionality is to have burns on an ERC 1155 be subject to a signature by a contract admin address. 